### PR TITLE
[UPDATE] 아이템 리스폰 시스템 완성 #16

### DIFF
--- a/Assets/Prefabs/Map/MapLimitObject.prefab
+++ b/Assets/Prefabs/Map/MapLimitObject.prefab
@@ -1,0 +1,74 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &302644644726364680
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2470982533142589863}
+  - component: {fileID: 187156562922657909}
+  - component: {fileID: 1846351528950579750}
+  m_Layer: 0
+  m_Name: MapLimitObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2470982533142589863
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 302644644726364680}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.14, y: 2, z: -1.9}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &187156562922657909
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 302644644726364680}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2b983ccc3d180b34786b2211a7c1732e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  OnItemLost:
+    m_PersistentCalls:
+      m_Calls: []
+  OnPlayerLost:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!65 &1846351528950579750
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 302644644726364680}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Map/MapLimitObject.prefab.meta
+++ b/Assets/Prefabs/Map/MapLimitObject.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4033e6fbf743c6d48a6f7269c5fc9d6a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Item/MapScripts/MapLimitObject.cs
+++ b/Assets/Scripts/Item/MapScripts/MapLimitObject.cs
@@ -6,34 +6,30 @@ using UnityEngine.Events;
 public class MapLimitObject : MonoBehaviour
 {
     /// <summary>
-    /// 해당 아이템이 맵의 지정된 범위를 벗어났을 때 호출될 이벤트.
+    /// 해당 아이템, 플레이어 캐릭터가 맵의 지정된 범위를 벗어났을 때 호출될 이벤트. 
+    /// 추후 필요한 동작을 추가할 수 있도록 해 두었음.
     /// </summary>
-    public UnityEvent OnItemLost;
-
-    // Start is called before the first frame update
-    void Start()
-    {
-        
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
+    [SerializeField] private UnityEvent OnItemLost;
+    [SerializeField] private UnityEvent OnPlayerLost;
 
     private void OnTriggerExit(Collider other)
     {
         if(other.CompareTag("Player"))
         {
-            
+            OnPlayerLost?.Invoke();
+            //플레이어 스폰포인트로 이동시키는 메소드 호출
         }
         else
         {
             ItemObject item = other.transform.GetComponent<ItemObject>();
             if (item != null)
             {
+                OnItemLost?.Invoke();
                 ItemManager.instance.RespawnItem(item);
+            }
+            else
+            {
+                Debug.Log("Is not Item");
             }
         }
     }


### PR DESCRIPTION
MapLimitObject Prefab, MapLimitObject.cs 추가.

MapLimitObject 객체에 닿은 아이템이나 플레이어 캐릭터가 지정된 스폰포인트로 순간이동하도록 하는 구조. 
프리펩을 복사해온 뒤, 크기를 원하는 대로 조정해서 사용하면 됨. 

플레이어 리스폰 부분은 추후 플레이어 부분이 완성되었을 때 추가할 예정임.