### PR TITLE
[ADD] PlayerRespawn #33

### DIFF
--- a/Assets/Scripts/Item/ItemScripts/Item_ScoreObject.cs
+++ b/Assets/Scripts/Item/ItemScripts/Item_ScoreObject.cs
@@ -31,10 +31,10 @@ public class Item_ScoreObject : ItemObject
     /// </summary>
     public new void OnPickUp()
     {
-        
         gameObject.SetActive(false);
 
         //플레이어의 점수 카운트 증가 + 플레이어 스폰포인트 지정
+
     }
 
     /// <summary>

--- a/Assets/Scripts/Item/MapScripts/MapLimitObject.cs
+++ b/Assets/Scripts/Item/MapScripts/MapLimitObject.cs
@@ -16,9 +16,17 @@ public class MapLimitObject : MonoBehaviour
     {
         if(other.CompareTag("Player"))
         {
-            OnPlayerLost?.Invoke();
-            other.transform.position = new Vector3(0,5,0);
-            //플레이어 스폰포인트로 이동시키는 메소드 호출
+            PlayerRespawn pr = other.transform.GetComponent<PlayerRespawn>();
+
+            if(pr != null)
+            {
+                OnPlayerLost?.Invoke();
+                pr.RespawnPlayer();
+            }
+            else
+            {
+                Debug.Log("Is not Player");
+            }
         }
         else
         {

--- a/Assets/Scripts/PlayerRespawn.cs
+++ b/Assets/Scripts/PlayerRespawn.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerRespawn : MonoBehaviour
+{
+    [SerializeField] private Vector3 checkPoint = new Vector3(0, 5, 0);
+
+    public void SetCheckPoint(Vector3 newCheckPoint)
+    {
+        checkPoint = newCheckPoint;
+    }
+
+    public void RespawnPlayer()
+    {
+        gameObject.transform.position = checkPoint;
+    }
+}

--- a/Assets/Scripts/PlayerRespawn.cs.meta
+++ b/Assets/Scripts/PlayerRespawn.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 82d59f4e2666cee478861c76bb2a00b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
플레이어 리스폰 정보와 메소드를 가지는 PlayerRespawn 클래스 추가.
리스폰 지점을 재설정하는 메소드 포함.

MapLimitObject 클래스 또한 이에 맞게 수정함.

이제 Player 프리펩의 Pelvis 에 PlayerRespawn.cs 를 추가해 주어야 플레이어 리스폰 기능이 작동한다.
