### PR TITLE
[UPDATE] 플레이어 스폰포인트를 재지정하는 아이템 구현 완료 #33

### DIFF
--- a/Assets/Prefabs/Item/Item_ScoreObjectTest.prefab
+++ b/Assets/Prefabs/Item/Item_ScoreObjectTest.prefab
@@ -50,6 +50,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   itemSO: {fileID: 11400000, guid: 11ae2aabc9682b64783e21b68c21b35c, type: 2}
   isGrabbed: 0
+  spawnPoint: {x: 0, y: 0, z: 0}
 --- !u!33 &4176887093253693954
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -115,7 +116,7 @@ CapsuleCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 2

--- a/Assets/Scenes/Map RollingLog.unity
+++ b/Assets/Scenes/Map RollingLog.unity
@@ -2358,6 +2358,79 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!1001 &1066391694
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 181354179603969217, guid: d500e91ceb486274e8c94e9f01979d24,
+        type: 3}
+      propertyPath: m_Name
+      value: Item_ScoreObjectTest
+      objectReference: {fileID: 0}
+    - target: {fileID: 2606239627061648082, guid: d500e91ceb486274e8c94e9f01979d24,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 2606239627061648082, guid: d500e91ceb486274e8c94e9f01979d24,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.8891201
+      objectReference: {fileID: 0}
+    - target: {fileID: 2606239627061648082, guid: d500e91ceb486274e8c94e9f01979d24,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 4.06
+      objectReference: {fileID: 0}
+    - target: {fileID: 2606239627061648082, guid: d500e91ceb486274e8c94e9f01979d24,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.97
+      objectReference: {fileID: 0}
+    - target: {fileID: 2606239627061648082, guid: d500e91ceb486274e8c94e9f01979d24,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9848078
+      objectReference: {fileID: 0}
+    - target: {fileID: 2606239627061648082, guid: d500e91ceb486274e8c94e9f01979d24,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.17364816
+      objectReference: {fileID: 0}
+    - target: {fileID: 2606239627061648082, guid: d500e91ceb486274e8c94e9f01979d24,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2606239627061648082, guid: d500e91ceb486274e8c94e9f01979d24,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2606239627061648082, guid: d500e91ceb486274e8c94e9f01979d24,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 2606239627061648082, guid: d500e91ceb486274e8c94e9f01979d24,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2606239627061648082, guid: d500e91ceb486274e8c94e9f01979d24,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d500e91ceb486274e8c94e9f01979d24, type: 3}
 --- !u!1 &1130528544
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Item/ItemScripts/Item_ScoreObject.cs
+++ b/Assets/Scripts/Item/ItemScripts/Item_ScoreObject.cs
@@ -26,13 +26,10 @@ public class Item_ScoreObject : ItemObject
         LevitateItem();
     }
 
-    /// <summary>
-    /// 해당 오브젝트를 비활성화시키고 플레이어 스폰포인트 재지정
-    /// </summary>
     public new void OnPickUp()
     {
         gameObject.SetActive(false);
-
+        PlayerRespawn.instance.SetCheckPoint(gameObject.transform.position);
     }
 
     /// <summary>
@@ -71,5 +68,17 @@ public class Item_ScoreObject : ItemObject
         //        isUp = true;
         //    }
         //}
+    }
+
+    /// <summary>
+    /// 해당 오브젝트를 비활성화시키고 플레이어 스폰포인트 재지정
+    /// </summary>
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.CompareTag("Player"))
+        {
+            gameObject.SetActive(false);
+            PlayerRespawn.instance.SetCheckPoint(gameObject.transform.position);
+        }
     }
 }


### PR DESCRIPTION
Item_ScoreObject 클래스에 해당 기능이 포함되어 있음. 

플레이어가 해당 아이템과 접촉 시 아이템 오브젝트가 비활성화되고, 플레이어의 스폰포인트가 해당 아이템의 좌표로 변경된다. 